### PR TITLE
Skip association groups with 0 max members

### DIFF
--- a/app/core/controllers/assoc.js
+++ b/app/core/controllers/assoc.js
@@ -94,13 +94,17 @@ appController.controller('ConfigAssocController', function($scope, $filter, $rou
             }
             if (0x85 in instance.commandClasses) {
                 for (var group = 0; group < instance.commandClasses[0x85].data.groups.value; group++) {
-                    dataService.runCmd('devices[' + nodeId + '].instances[' + index + '].commandClasses[0x85].Get(' + (group + 1) + ')', false, $scope._t('error_handling_data'), true);
+                    if (instance.commandClasses[0x85].data[group + 1].max.value > 0) {
+                        dataService.runCmd('devices[' + nodeId + '].instances[' + index + '].commandClasses[0x85].Get(' + (group + 1) + ')', false, $scope._t('error_handling_data'), true);    
+                    }
+                    
                 }
             }
             if (0x8e in instance.commandClasses) {
                 for (var group = 0; group < instance.commandClasses[0x8e].data.groups.value; group++) {
-                    dataService.runCmd('devices[' + nodeId + '].instances[' + index + '].commandClasses[0x8e].Get(' + (group + 1) + ')', false, $scope._t('error_handling_data'), true);
-
+                    if (instance.commandClasses[0x8e].data[group + 1].max.value) {
+                        dataService.runCmd('devices[' + nodeId + '].instances[' + index + '].commandClasses[0x8e].Get(' + (group + 1) + ')', false, $scope._t('error_handling_data'), true);
+                    }
                 }
             }
             $timeout(function() {
@@ -117,8 +121,8 @@ appController.controller('ConfigAssocController', function($scope, $filter, $rou
     $scope.modalAssocAdd = function(group) {
         $scope.input.groupCfg = group;
         $scope.input.groupId = group.groupId;
-        $scope.assocAddDevices = [];
         // Prepare devices and nodes
+
         angular.forEach($scope.ZWaveAPIData.devices, function(node, nodeId) {
             if (nodeId == 255 || node.data.isVirtual.value || nodeId == $scope.deviceId) {
                 return;
@@ -452,7 +456,13 @@ appController.controller('ConfigAssocController', function($scope, $filter, $rou
                         timeClass: updateTime > invalidateTime ? 'undef' : 'red',
                         remaining: (data.max.value - $filter('unique')(nodeIds).length)
                     };
-                    assocGroups.push(obj);
+                    
+                    // Don't return groups that have 0 max nodes. Happens with Aspire RF devices
+                    // like the RFWC5
+                    if (max || data.max.value) {
+                        assocGroups.push(obj);
+                    }
+                    
                 }
             }
         });


### PR DESCRIPTION
Some devices like the Aspire RF RFWC5 from Cooper report over 250
groups with 0 max members. Skip all these groups in the GUI and do not
issue commands to refresh all the groups as it generates hundreds or
thousands of requests at once in the controller queue